### PR TITLE
Use int64 for TimeEntry.Duration

### DIFF
--- a/timeentry.go
+++ b/timeentry.go
@@ -15,7 +15,7 @@ type TimeEntry struct {
 	Project     *gproject.Project     `json:"project"`
 	Start       time.Time             `json:"start"`
 	Stop        time.Time             `json:"stop"`
-	Duration    uint64                `json:"duration"`
+	Duration    int64                 `json:"duration"`
 	Billable    bool                  `json:"billable"`
 	Workspace   *gworkspace.Workspace `json:"workspace"`
 	Tags        []string              `json:"tags"`


### PR DESCRIPTION
The Toggl API docs indicate that the duration is negative for ongoing time entries.

https://github.com/toggl/toggl_api_docs/blob/master/chapters/time_entries.md#time-entries
