### PR TITLE
Get time entries started in a specific time range

### DIFF
--- a/mock/GET/api/v8/time_entries?end=2013-03-12T15%3A42%3A46%2B02%3A00&start=2013-03-10T15%3A42%3A46%2B02%3A00.json
+++ b/mock/GET/api/v8/time_entries?end=2013-03-12T15%3A42%3A46%2B02%3A00&start=2013-03-10T15%3A42%3A46%2B02%3A00.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": 4,
+    "wid": 777,
+    "pid": 123,
+    "billable": true,
+    "start": "2013-03-11T11:36:00+00:00",
+    "stop": "2013-03-11T15:36:00+00:00",
+    "duration": 14400,
+    "description": "Meeting with the client",
+    "tags": [
+      ""
+    ],
+    "at": "2013-03-11T15:36:58+00:00"
+  },
+  {
+    "id": 5,
+    "wid": 777,
+    "billable": false,
+    "start": "2013-03-12T10:32:43+00:00",
+    "stop": "2013-03-12T14:32:43+00:00",
+    "duration": 18400,
+    "description": "important work",
+    "tags": [
+      ""
+    ],
+    "at": "2013-03-12T14:32:43+00:00"
+  }
+]

--- a/timeentry.go
+++ b/timeentry.go
@@ -7,6 +7,7 @@ import (
 	"gopkg.in/dougEfresh/toggl-project.v8"
 	"gopkg.in/dougEfresh/toggl-workspace.v8"
 	"time"
+	"net/url"
 )
 
 type TimeEntry struct {
@@ -84,6 +85,22 @@ func (c *TimeEntryClient) Create(t *TimeEntry) (*TimeEntry, error) {
 func (c *TimeEntryClient) Update(t *TimeEntry) (*TimeEntry, error) {
 	up := map[string]interface{}{"time_entry": t}
 	return timeEntryResponse(c.thc.PutRequest(fmt.Sprintf("%s/%d", c.endpoint, t.Id), up))
+}
+
+func (c *TimeEntryClient) GetRange(start time.Time, end time.Time) (TimeEntries, error) {
+	v := url.Values{}
+	v.Set("start", start.Format(time.RFC3339))
+	v.Set("end", end.Format(time.RFC3339))
+	body, err := c.thc.GetRequest(fmt.Sprintf("%s?%s", c.endpoint, v.Encode()))
+	var te TimeEntries
+	if err != nil {
+		return te, err
+	}
+	if body == nil {
+		return nil, nil
+	}
+	err = json.Unmarshal(*body, &te)
+	return te, err
 }
 
 func timeEntryResponse(response *json.RawMessage, error error) (*TimeEntry, error) {

--- a/timeentry_test.go
+++ b/timeentry_test.go
@@ -96,6 +96,25 @@ func TestTimeEntryGet(t *testing.T) {
 	}
 }
 
+func TestTimeEntryGetTimeRange(t *testing.T) {
+	tClient := togglClient(t)
+
+	start, _ := time.Parse(time.RFC3339, "2013-03-10T15:42:46+02:00")
+	end , _:= time.Parse(time.RFC3339, "2013-03-12T15:42:46+02:00")
+
+	te, err := tClient.GetRange(start, end)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(te) < 1 {
+		t.Fatal("<1")
+	}
+	timeentry := te[0]
+	if timeentry.Id != 4 {
+		t.Error("!= 4")
+	}
+}
+
 func BenchmarkTimeEntryClient_Get(b *testing.B) {
 	b.ReportAllocs()
 	tClient := togglClient(nil)


### PR DESCRIPTION
Toggl API supports to get time entries in a specific time range.

And, I did it.

But, your test library `toggl-test` doesn't support URLs query. I create pull-request that solve this problem. 

see dougEfresh/toggl-test#1